### PR TITLE
Add launch files for wobbly and wibbly

### DIFF
--- a/VapourSynth64Portable/VapourSynth64/wibbly.bat
+++ b/VapourSynth64Portable/VapourSynth64/wibbly.bat
@@ -1,0 +1,2 @@
+cd .
+wobbly-win64\wibbly.exe

--- a/VapourSynth64Portable/VapourSynth64/wobbly.bat
+++ b/VapourSynth64Portable/VapourSynth64/wobbly.bat
@@ -1,0 +1,2 @@
+cd .
+wobbly-win64\wobbly.exe


### PR DESCRIPTION
When you want to launch wobbly.exe or wibbly.exe directly in the wobbly-win64 folder, they can't find VSScript.dll and VapourSynth because they are located in the parent folder. To solve this issue, I created files that start Wobbly and Wibbly at the root of VapourSynth and Python.